### PR TITLE
updated index.js to ensure afterEmit hook exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ function toArray(value) {
 
 /** Backwards compatible version of `compiler.plugin.afterEmit.tapAsync()`. */
 function attachAfterEmitHook(compiler, callback) {
-  if (compiler.hooks) {
+  if (compiler.hooks && compiler.hooks.afterEmit) {
     compiler.hooks.afterEmit.tapAsync('SentryCliPlugin', callback);
   } else {
     compiler.plugin('after-emit', callback);


### PR DESCRIPTION
updated index.js to ensure afterEmit hook exists because with the current setup, it assumes afterEmit hook exists (by checking if compiler.hooks).